### PR TITLE
Bug 393073 [WIP] - NPE in the hasNext method

### DIFF
--- a/org.eclipse.lyo.client.java/src/main/java/org/eclipse/lyo/client/oslc/resources/OslcQueryResult.java
+++ b/org.eclipse.lyo.client.java/src/main/java/org/eclipse/lyo/client/oslc/resources/OslcQueryResult.java
@@ -53,7 +53,7 @@ import com.hp.hpl.jena.vocabulary.RDFS;
 public class OslcQueryResult implements Iterator<OslcQueryResult> {
 	/**
 	 * The default member property to look for in OSLC query results
-	 * (rdfs:member). Can be changed using {@link #setMemberProperty(Property)}.
+	 * (rdfs:member). Can be changed using {@link #setMemberProperty(String)}.
 	 */
 	public final static Property DEFAULT_MEMBER_PROPERTY = RDFS.member;
 
@@ -73,14 +73,13 @@ public class OslcQueryResult implements Iterator<OslcQueryResult> {
 	    }
 
 	    public boolean selects(Statement s) {
-	    	String fqPredicateName = s.getPredicate().getNameSpace() + s.getPredicate().getLocalName();
-	    	if (OSLCConstants.RDF_TYPE_PROP.equals(fqPredicateName)) {
-	    		return false;
-	    	}
+			String fqPredicateName = s.getPredicate().getNameSpace() + s.getPredicate()
+					.getLocalName();
+			return !OSLCConstants.RDF_TYPE_PROP.equals(fqPredicateName) && s.getObject()
+					.isResource();
 
-	    	return s.getObject().isResource();
-	    }
-    }
+		}
+	}
 
 	private final OslcQuery query;
 
@@ -101,20 +100,15 @@ public class OslcQueryResult implements Iterator<OslcQueryResult> {
 	public OslcQueryResult(OslcQuery query, ClientResponse response) {
 		this.query = query;
 		this.response = response;
-
 		this.pageNumber = 1;
-
-
 	}
 
 	private OslcQueryResult(OslcQueryResult prev) {
-		this.query = new OslcQuery(prev);
+		this.query = prev.query;
 		this.response = this.query.getResponse();
 		this.membersResource = prev.membersResource;
 		this.memberProperty = prev.memberProperty;
-
 		this.pageNumber = prev.pageNumber + 1;
-
 	}
 
 	private synchronized void initializeRdf() {
@@ -128,11 +122,10 @@ public class OslcQueryResult implements Iterator<OslcQueryResult> {
 			Property responseInfo = rdfModel.createProperty(OslcConstants.OSLC_CORE_NAMESPACE, "ResponseInfo");
 			ResIterator iter = rdfModel.listResourcesWithProperty(rdfType, responseInfo);
 
-			//There should only be one - take the first
 			infoResource = null;
-			while (iter.hasNext()) {
+			if (iter.hasNext()) {
+				// There should only be one - take the first
 				infoResource = iter.next();
-				break;
 			}
 			membersResource = rdfModel.getResource(query.getCapabilityUrl());
 		}
@@ -146,7 +139,8 @@ public class OslcQueryResult implements Iterator<OslcQueryResult> {
 			StmtIterator iter = rdfModel.listStatements(select);
 			if (iter.hasNext()) {
 				Statement nextPage = iter.next();
-				nextPageUrl = nextPage.getResource().getURI();
+				final Resource nextPageResource = nextPage.getResource();
+				nextPageUrl = nextPageResource.getURI();
 			} else {
 				nextPageUrl = "";
 			}
@@ -158,12 +152,13 @@ public class OslcQueryResult implements Iterator<OslcQueryResult> {
 	 * @return whether there is another page of results after this
 	 */
 	public boolean hasNext() {
-		return (!"".equals(getNextPageUrl()));
+		final String nextPageUrl = getNextPageUrl();
+		final boolean nextUrlNotEmpty = nextPageUrl != null && nextPageUrl.trim().length() > 0;
+		return nextUrlNotEmpty;
 	}
 
 	/**
 	 * @return the next page of results
-	 * @throws NoSuchElementException if there is no next page
 	 */
 	public OslcQueryResult next() {
 		return new OslcQueryResult(this);
@@ -234,7 +229,7 @@ public class OslcQueryResult implements Iterator<OslcQueryResult> {
 	 */
 	public String[] getMembersUrls() {
 		initializeRdf();
-		ArrayList<String> membersUrls = new ArrayList<String>();
+		ArrayList<String> membersUrls = new ArrayList<>();
         Selector select = getMemberSelector();
 		StmtIterator iter = rdfModel.listStatements(select);
 		while (iter.hasNext()) {
@@ -247,7 +242,6 @@ public class OslcQueryResult implements Iterator<OslcQueryResult> {
 	/**
 	 * Return the enumeration of queried results from this page
 	 *
-	 * @param T
 	 * @param clazz
 	 *
 	 * @return member statements from current page.
@@ -257,47 +251,30 @@ public class OslcQueryResult implements Iterator<OslcQueryResult> {
 
         Selector select = getMemberSelector();
         final StmtIterator iter = rdfModel.listStatements(select);
-        Iterable<T> result = new Iterable<T>() {
-                public Iterator<T>
-                iterator() {
-                    return new Iterator<T>() {
-                            public boolean hasNext() {
-                                return iter.hasNext();
-                            }
+		Iterable<T> result = () -> new Iterator<T>() {
+			public boolean hasNext() {
+				return iter.hasNext();
+			}
 
-                            @SuppressWarnings("unchecked")
-                            public T next() {
-                                Statement member = iter.next();
+			@SuppressWarnings("unchecked")
+			public T next() {
+				Statement member = iter.next();
 
-                                try {
-                                    return (T)JenaModelHelper.fromJenaResource((Resource)member.getObject(), clazz);
-                                } catch (IllegalArgumentException e) {
-                                   throw new IllegalStateException(e.getMessage());
-                                } catch (SecurityException e) {
-                                    throw new IllegalStateException(e.getMessage());
-                                } catch (DatatypeConfigurationException e) {
-                                    throw new IllegalStateException(e.getMessage());
-                                } catch (IllegalAccessException e) {
-                                    throw new IllegalStateException(e.getMessage());
-                                } catch (InstantiationException e) {
-                                    throw new IllegalStateException(e.getMessage());
-                                } catch (InvocationTargetException e) {
-                                    throw new IllegalStateException(e.getMessage());
-                                } catch (OslcCoreApplicationException e) {
-                                    throw new IllegalStateException(e.getMessage());
-                                } catch (URISyntaxException e) {
-                                    throw new IllegalStateException(e.getMessage());
-                                } catch (NoSuchMethodException e) {
-                                    throw new IllegalStateException(e.getMessage());
-                                }
-                            }
+				try {
+					return (T) JenaModelHelper.fromJenaResource((Resource) member.getObject(),
+							clazz);
+				} catch (IllegalArgumentException | SecurityException | IllegalAccessException |
+						DatatypeConfigurationException | InvocationTargetException |
+						InstantiationException | URISyntaxException | OslcCoreApplicationException
+						| NoSuchMethodException e) {
+					throw new IllegalStateException(e.getMessage());
+				}
+			}
 
-                            public void remove() {
-                                iter.remove();
-                            }
-                        };
-                }
-            };
+			public void remove() {
+				iter.remove();
+			}
+		};
 
         return result;
     }

--- a/org.eclipse.lyo.client.java/src/test/java/org/eclipse/lyo/client/test/OslcQueryResultTest.java
+++ b/org.eclipse.lyo.client.java/src/test/java/org/eclipse/lyo/client/test/OslcQueryResultTest.java
@@ -17,7 +17,7 @@
  *******************************************************************************/
 package org.eclipse.lyo.client.test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
 
 import java.io.InputStream;
@@ -70,6 +70,30 @@ public class OslcQueryResultTest {
 		 OslcQuery query = new OslcQuery(new OslcClient(), "http://example.com/provider/query", params);
 		 OslcQueryResult result = new OslcQueryResult(query, mockedResponse);
 		 assertEquals(2, result.getMembersUrls().length);
+	}
+
+	@Test
+	public void testQueryResultHasNext() {
+		ClientResponse mockedResponse = mockClientResponse("/queryResponseWithNext.xml");
+
+		OslcQueryParameters params = new OslcQueryParameters();
+		params.setWhere("ex:product=\"Product A\"");
+		OslcQuery query = new OslcQuery(new OslcClient(), "http://example.com/provider/query",
+				params);
+		OslcQueryResult result = new OslcQueryResult(query, mockedResponse);
+		assertTrue("Next URI resource should be detected", result.hasNext());
+	}
+
+	@Test
+	public void testQueryResultWithEmptyNext() {
+		ClientResponse mockedResponse = mockClientResponse("/queryResponseWithEmptyNext.xml");
+
+		OslcQueryParameters params = new OslcQueryParameters();
+		params.setWhere("ex:product=\"Product A\"");
+		OslcQuery query = new OslcQuery(new OslcClient(), "http://example.com/provider/query",
+				params);
+		OslcQueryResult result = new OslcQueryResult(query, mockedResponse);
+		assertFalse("Empty Next URI resource should be ignored", result.hasNext());
 	}
 
 	@Test

--- a/org.eclipse.lyo.client.java/src/test/resources/queryResponseWithEmptyNext.xml
+++ b/org.eclipse.lyo.client.java/src/test/resources/queryResponseWithEmptyNext.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:oslc="http://open-services.net/ns/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+		xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+	<oslc:ResponseInfo rdf:about="http://example.com/provider/query?oslc.where=ex%3Aproduct%3D%22Product%20A%2">
+		<oslc:totalCount rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2</oslc:totalCount>
+		<oslc:nextPage rdf:resource="" />
+	</oslc:ResponseInfo>
+	<rdf:Description rdf:about="http://example.com/provider/query">
+		<rdfs:member rdf:resource="http://example.com/resources/1"/>
+		<rdfs:member rdf:resource="http://example.com/resources/3"/>
+	</rdf:Description>
+</rdf:RDF>

--- a/org.eclipse.lyo.client.java/src/test/resources/queryResponseWithNext.xml
+++ b/org.eclipse.lyo.client.java/src/test/resources/queryResponseWithNext.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:oslc="http://open-services.net/ns/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+		xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+	<oslc:ResponseInfo rdf:about="http://example.com/provider/query?oslc.where=ex%3Aproduct%3D%22Product%20A%2">
+		<oslc:totalCount rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2</oslc:totalCount>
+		<oslc:nextPage rdf:resource="http://example.com/provider/query?oslc
+		.where=ex%3Aproduct%3D%22Product%20A%2&amp;page=2" />
+	</oslc:ResponseInfo>
+	<rdf:Description rdf:about="http://example.com/provider/query">
+		<rdfs:member rdf:resource="http://example.com/resources/1"/>
+		<rdfs:member rdf:resource="http://example.com/resources/3"/>
+	</rdf:Description>
+</rdf:RDF>


### PR DESCRIPTION
Current status is that the empty nextPage property:

<oslc:nextPage rdf:resource="" />

Causes Jena to deserialise a full triple statement with a non-empty
Object:

subject = "http://example.com/provider/query?oslc.where=ex%3Aproduct%3D%22Product%20A%2"
predicate = "http://open-services.net/ns/core#nextPage"
object = "http://example.com/provider/query"
