### PR TITLE
Remove final from resource classes

### DIFF
--- a/oslc-java-client/src/main/java/org/eclipse/lyo/client/oslc/resources/ArchitectureLinkType.java
+++ b/oslc-java-client/src/main/java/org/eclipse/lyo/client/oslc/resources/ArchitectureLinkType.java
@@ -40,7 +40,7 @@ import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
 /**
  * @see http://open-services.net/wiki/architecture-management/OSLC-Architecture-Management-Specification-Version-2.0/
  */
-public final class ArchitectureLinkType
+public class ArchitectureLinkType
 extends AbstractResource
 {
 	private final Set<URI>      contributors                = new TreeSet<URI>();

--- a/oslc-java-client/src/main/java/org/eclipse/lyo/client/oslc/resources/ArchitectureResource.java
+++ b/oslc-java-client/src/main/java/org/eclipse/lyo/client/oslc/resources/ArchitectureResource.java
@@ -42,7 +42,7 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 /**
  * @see http://open-services.net/wiki/architecture-management/OSLC-Architecture-Management-Specification-Version-2.0/
  */
-public final class ArchitectureResource
+public class ArchitectureResource
 extends AbstractResource
 {
 	private final Set<URI>      contributors                = new TreeSet<URI>();

--- a/oslc-java-client/src/main/java/org/eclipse/lyo/client/oslc/resources/AutomationPlan.java
+++ b/oslc-java-client/src/main/java/org/eclipse/lyo/client/oslc/resources/AutomationPlan.java
@@ -42,7 +42,7 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 /**
  * @see http://open-services.net/wiki/automation/OSLC-Automation-Specification-Version-2.0/#Resource_AutomationPlan
  */
-public final class AutomationPlan
+public class AutomationPlan
 extends AbstractResource
 {
 	private final Set<URI>      contributors                = new TreeSet<URI>();

--- a/oslc-java-client/src/main/java/org/eclipse/lyo/client/oslc/resources/AutomationRequest.java
+++ b/oslc-java-client/src/main/java/org/eclipse/lyo/client/oslc/resources/AutomationRequest.java
@@ -43,7 +43,7 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 /**
  * @see http://open-services.net/wiki/automation/OSLC-Automation-Specification-Version-2.0/#Resource_AutomationRequest
  */
-public final class AutomationRequest
+public class AutomationRequest
 extends AbstractResource
 {
 	private final Set<URI>      contributors                = new TreeSet<URI>();

--- a/oslc-java-client/src/main/java/org/eclipse/lyo/client/oslc/resources/AutomationResult.java
+++ b/oslc-java-client/src/main/java/org/eclipse/lyo/client/oslc/resources/AutomationResult.java
@@ -43,7 +43,7 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 /**
  * @see http://open-services.net/wiki/automation/OSLC-Automation-Specification-Version-2.0/#Resource_AutomationResult
  */
-public final class AutomationResult
+public class AutomationResult
 extends AbstractResource
 {
 	private final Set<URI>      contributors                = new TreeSet<URI>();

--- a/oslc-java-client/src/main/java/org/eclipse/lyo/client/oslc/resources/ChangeRequest.java
+++ b/oslc-java-client/src/main/java/org/eclipse/lyo/client/oslc/resources/ChangeRequest.java
@@ -45,7 +45,7 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 
 @OslcNamespace(CmConstants.CHANGE_MANAGEMENT_NAMESPACE)
 @OslcResourceShape(title = "Change Request Resource Shape", describes = CmConstants.TYPE_CHANGE_REQUEST)
-public final class ChangeRequest
+public class ChangeRequest
        extends AbstractResource
 {
     private final Set<Link>     affectedByDefects           = new HashSet<Link>();

--- a/oslc-java-client/src/main/java/org/eclipse/lyo/client/oslc/resources/RequirementCollection.java
+++ b/oslc-java-client/src/main/java/org/eclipse/lyo/client/oslc/resources/RequirementCollection.java
@@ -33,7 +33,7 @@ import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
 
 @OslcNamespace(RmConstants.REQUIREMENTS_MANAGEMENT_NAMESPACE)
 @OslcResourceShape(title = "Requirement Collection Resource Shape", describes = RmConstants.TYPE_REQUIREMENT_COLLECTION)
-public final class RequirementCollection
+public class RequirementCollection
        extends Requirement
 {
 	// The only extra field is uses

--- a/oslc-java-client/src/main/java/org/eclipse/lyo/client/oslc/resources/TestCase.java
+++ b/oslc-java-client/src/main/java/org/eclipse/lyo/client/oslc/resources/TestCase.java
@@ -39,7 +39,7 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 /**
  * @see http://open-services.net/bin/view/Main/QmSpecificationV2#Resource_TestCase
  */
-public final class TestCase
+public class TestCase
        extends QmResource
 {
     private final Set<URI>      contributors                = new TreeSet<URI>();

--- a/oslc-java-client/src/main/java/org/eclipse/lyo/client/oslc/resources/TestExecutionRecord.java
+++ b/oslc-java-client/src/main/java/org/eclipse/lyo/client/oslc/resources/TestExecutionRecord.java
@@ -37,7 +37,7 @@ import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
 /**
  * @see http://open-services.net/bin/view/Main/QmSpecificationV2#Resource_TestExecutionRecord
  */
-public final class TestExecutionRecord
+public class TestExecutionRecord
        extends QmResource
 {
     private final Set<Link>     blockedByChangeRequests       = new HashSet<Link>();

--- a/oslc-java-client/src/main/java/org/eclipse/lyo/client/oslc/resources/TestPlan.java
+++ b/oslc-java-client/src/main/java/org/eclipse/lyo/client/oslc/resources/TestPlan.java
@@ -39,7 +39,7 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 /**
  * @see http://open-services.net/bin/view/Main/QmSpecificationV2#Resource_TestPlan
  */
-public final class TestPlan
+public class TestPlan
        extends QmResource
 {
 	private final Set<URI>      contributors                = new TreeSet<URI>();

--- a/oslc-java-client/src/main/java/org/eclipse/lyo/client/oslc/resources/TestResult.java
+++ b/oslc-java-client/src/main/java/org/eclipse/lyo/client/oslc/resources/TestResult.java
@@ -39,7 +39,7 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 /**
  * @see http://open-services.net/bin/view/Main/QmSpecificationV2#Resource_TestResult
  */
-public final class TestResult
+public class TestResult
        extends QmResource
 {
     private final Set<Link>     affectedByChangeRequests       = new HashSet<Link>();

--- a/oslc-java-client/src/main/java/org/eclipse/lyo/client/oslc/resources/TestScript.java
+++ b/oslc-java-client/src/main/java/org/eclipse/lyo/client/oslc/resources/TestScript.java
@@ -39,7 +39,7 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 /**
  * @see http://open-services.net/bin/view/Main/QmSpecificationV2#Resource_TestScript
  */
-public final class TestScript
+public class TestScript
        extends QmResource
 {
     private final Set<URI>      contributors                = new TreeSet<URI>();


### PR DESCRIPTION
Extending from ChangeRequest or other resource classes is not possible, handling extra properties in extendedProperties is tedious. By removing final modifier from those classes, programmers can add their own properties.

Signed-off-by: Ricardo Herrera <neormx@gmail.com>